### PR TITLE
Bootstrap logging bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,25 @@
 
 This solves the 🐓 and 🥚 problem: How do you Terraform the remote state bucket? It takes the approach of keeping a local statefile in the repo that only manages these resources:
 
-* S3 bucket for remote state file (using the [s3-private-bucket](https://registry.terraform.io/modules/trussworks/s3-private-bucket/aws) module)
+* S3 bucket for remote state file (using the TrussWorks [s3-private-bucket module](https://registry.terraform.io/modules/trussworks/s3-private-bucket/aws))
+* S3 bucket for storing state bucket access logs (using the TrussWorks [logs module](https://registry.terraform.io/modules/trussworks/logs/aws))
 * DynamoDB table for state locking and consistency checking
-
-## Caveats
-
-The current version of the [s3-private-bucket](https://github.com/trussworks/terraform-aws-s3-private-bucket) module expects a logging bucket to be specified. If you're on a greenfield project without that bucket yet, you can change `main.tf` to use v1.4.0 of the module and drop the `logging_bucket` parameter:
-
-```hcl
-module "terraform-state-bucket" {
-  source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 1.4.0"
-  bucket  = "terraform-state-${var.region}"
-}
-```
-
-When invoking the `bootstrap` script, specify a dummy logging bucket parameter.
-
-We hope to [fix this](https://github.com/trussworks/terraform-aws-s3-private-bucket/issues/8) in a future version.
 
 ## Bootstrapping
 
 Copy the code in this repo to where your Terraform config will live. For example, it could live in a directory like `terraform/account-alias/bootstrap`.
 
-Run the `bootstrap` script, specifying your AWS account alias, region, and logging bucket:
+Run the `bootstrap` script, specifying your AWS account alias and region:
 
 ```text
-./bootstrap my-account-alias us-west-2 my-aws-logging-bucket
+./bootstrap my-account-alias us-west-2
 ```
 
-The account alias will configured (if not set), the resources will be created, and a git commit will be made with the region and statefile. Push those changes to your repo.
+The account alias will configured (if not set), the resources will be created, and a git commit will be made with the tfvars and state files. Push those changes to your repo.
+
+## Pre-existing environments
+
+The code can be customized for specific environments. For example, if you're bootstrapping Terraform into an existing environment, you may want to use an existing logging bucket for the S3 logs. Edit the Terraform and bootstrap script as you need.
 
 ## Subsequent changes
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,30 +1,43 @@
 #!/bin/bash
 #
 #   For brand new AWS accounts, this script will configure the account alias
-#   prior to applying Terraform. It will only run if the alias and bucket do
-#   not exist.
+#   prior to applying Terraform. It will exit if the state bucket already
+#   exists.
 #
 set -e -o pipefail
 
 usage() {
-    echo "Usage: $0 <account-alias> <region> <logging_bucket>"
+    echo "Usage: $0 <account-alias> <region>"
     exit 1
 }
-[[ -z $1 || -z $2 || -z $3 ]] && usage
+[[ -z $1 || -z $2 ]] && usage
 set -u
 
 readonly account_alias=$1
 readonly region=$2
-readonly logging_bucket=$3
 
-readonly bucket=${account_alias}-terraform-state-${region}
+readonly state_bucket=${account_alias}-terraform-state-${region}
+readonly logging_bucket=${account_alias}-terraform-state-logs-${region}
 readonly tfvars_file=terraform.tfvars
 
-# Bail out if the bucket already exists
-status=$(aws s3 ls "s3://$bucket/" 2>&1 | grep -o 'bucket does not exist') || true
-if [[ $status != 'bucket does not exist' ]]; then
+bucket_exists() {
+    bucket=$1
+    status=$(aws s3 ls "s3://$bucket/" 2>&1 | grep -o 'bucket does not exist') || true
+    [[ $status != 'bucket does not exist' ]]
+}
+
+
+# Bail out if the state bucket already exists
+if bucket_exists "$state_bucket"; then
     set +x
-    echo -e '\nLooks like the bucket '"$bucket"' already exists!'
+    echo -e '\nLooks like the bucket '"$state_bucket"' already exists!'
+    exit 1
+fi
+
+# Bail out if the logging bucket already exists
+if bucket_exists "$logging_bucket"; then
+    set +x
+    echo -e '\nLooks like the bucket '"$logging_bucket"' already exists!'
     exit 1
 fi
 
@@ -37,10 +50,13 @@ elif [[ $current_alias != "$account_alias" ]]; then
     exit 1
 fi
 
-# Generate terraform.tfvars with the chosen AWS region
+# Generate terraform.tfvars with user settings
 rm -f $tfvars_file
-echo "region = \"$region\"" >> $tfvars_file
-echo "logging_bucket = \"$logging_bucket\"" >> $tfvars_file
+{
+    echo "region = \"$region\""
+    echo "state_bucket = \"$state_bucket\""
+    echo "logging_bucket = \"$logging_bucket\""
+} >> $tfvars_file
 terraform fmt $tfvars_file > /dev/null
 
 # Create resources

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 
 module "terraform-state-bucket" {
   source         = "trussworks/s3-private-bucket/aws"
-  version        = "~> 1.5.0"
+  version        = "~> 1.6.0"
   bucket         = "terraform-state-${var.region}"
   logging_bucket = "${var.logging_bucket}"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,8 @@
 provider "aws" {
-  version = "~> 1.41.0"
+  version = "~> 1.60.0"
   region  = "${var.region}"
 }
 
 provider "template" {
-  version = "~> 1.0.0"
+  version = "~> 2.1.0"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.11.10"
+  required_version = "~> 0.11.11"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,12 @@ variable "region" {
   type        = "string"
 }
 
+variable "state_bucket" {
+  description = "S3 bucket to store Terraform state in ."
+  type        = "string"
+}
+
 variable "logging_bucket" {
-  description = "S3 bucket to send S3 access logs."
+  description = "S3 bucket to send state_bucket access logs to."
   type        = "string"
 }


### PR DESCRIPTION
This solves an additional 🐓 and 🥚 problem in brand new accounts: We want the new Terraform state bucket to log access to a logging bucket, but there is no logging bucket. 

The tact here is to create a new logging bucket specifically for logging state bucket access. For environments where there is an existing logging bucket, it's straight forward to change things to use that, whereas not having a logging bucket meant that there was a 2-phase process for bootstrapping.
