### PR TITLE
Make tags an argument instead of a block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
     type = "S"
   }
 
-  tags {
+  tags = {
     Name       = "terraform-state-lock"
     Automation = "Terraform"
   }


### PR DESCRIPTION
This fixes the syntax so it works with both Terraform 0.11 and 0.12.