### PR TITLE
Updating for tf12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,12 +21,11 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 2.0.0"
+  version = "~> 3.0.0"
   region  = "${var.region}"
 
   s3_bucket_name = "${var.logging_bucket}"
 
-  allow_s3      = true
   default_allow = false
 }
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 1.60.0"
+  version = "~> 2.18.0"
   region  = "${var.region}"
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.11.11"
+  required_version = "~> 0.12.3"
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,0 @@
-terraform {
-  required_version = "~> 0.12.3"
-}


### PR DESCRIPTION
Not sure we want to merge this in yet, but this is just capturing the work @brainsik and I did yesterday to bootstrap for tf12; updates the Terraform version, the aws provider version, and the terraform-aws-logs module version.