### PR TITLE
Bugfixes to bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ If the AWS account you are using already has a Terraform state bucket and lockin
 
 Copy the code in this repo to where your Terraform config will live. For example, it could live in a directory like `terraform/account-alias/bootstrap`.
 
-If your `aws` commands run via [aws-vault](https://github.com/99designs/aws-vault), you'll need to set the `--no-session` flag so the IAM operations can run without being MFA'd. If you're using the [Truss aws-vault-wrapper](https://github.com/trussworks/terraform-layout-example/blob/master/bin/aws-vault-wrapper) you can set the `AWS_VAULT_NO_SESSION` environment variable. If you don't do this you'll receive an `InvalidClientTokenId` error.
+If your `aws` commands run via [aws-vault](https://github.com/99designs/aws-vault), you'll need to set the `--no-session` flag so the IAM operations can run without being MFA'd. If you're using the [Truss aws-vault-wrapper](https://github.com/trussworks/terraform-layout-example/blob/master/bin/aws-vault-wrapper) you can set the `AWS_VAULT_NO_SESSION` environment variable. If you don't do this you'll receive an `InvalidClientTokenId` error. 
+
+If you are running the aws-vault-wrapper as noted above, you will want to run this script without `AWS_VAULT_NO_SESSION`. The role assumption between different profiles requires session behavior. Additionally, this script will attempt to run `aws s3 ls` before checking for bucket existence so that you can create a session token that may require an MFA handshake.
 
 Run the `bootstrap` script, specifying your AWS account alias and region:
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ If the AWS account you are using already has a Terraform state bucket and lockin
 
 Copy the code in this repo to where your Terraform config will live. For example, it could live in a directory like `terraform/account-alias/bootstrap`.
 
-If your `aws` commands run via [aws-vault](https://github.com/99designs/aws-vault), you'll need to set the `--no-session` flag so the IAM operations can run without being MFA'd. If you're using the [Truss aws-vault-wrapper](https://github.com/trussworks/terraform-layout-example/blob/master/bin/aws-vault-wrapper) you can set the `AWS_VAULT_NO_SESSION` environment variable. If you don't do this you'll receive an `InvalidClientTokenId` error.
+If your `aws` commands run via [aws-vault](https://github.com/99designs/aws-vault) and you are using root credentials, you'll need to set the `--no-session` flag so the IAM operations can run without being MFA'd. If you're using the [Truss aws-vault-wrapper](https://github.com/trussworks/terraform-layout-example/blob/master/bin/aws-vault-wrapper) you can set the `AWS_VAULT_NO_SESSION` environment variable. If you don't do this you'll receive an `InvalidClientTokenId` error.
 
-If you are running the aws-vault-wrapper as noted above, you will want to run this script without `AWS_VAULT_NO_SESSION`. The role assumption between different profiles requires session behavior. Additionally, this script will attempt to run `aws s3 ls` before checking for bucket existence so that you can create a session token that may require an MFA handshake.
+If you are running your `aws` commands via [aws-vault](https://github.com/99designs/aws-vault) and are using a role assumption, you will want to run this script without `AWS_VAULT_NO_SESSION`. The role assumption between different profiles requires session behavior. Additionally, this script will attempt to run `aws s3 ls` before checking for bucket existence so that you can create a session token that may require an MFA handshake.
 
 Run the `bootstrap` script, specifying your AWS account alias and region:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If the AWS account you are using already has a Terraform state bucket and lockin
 
 Copy the code in this repo to where your Terraform config will live. For example, it could live in a directory like `terraform/account-alias/bootstrap`.
 
-If your `aws` commands run via [aws-vault](https://github.com/99designs/aws-vault), you'll need to set the `--no-session` flag so the IAM operations can run without being MFA'd. If you're using the [Truss aws-vault-wrapper](https://github.com/trussworks/terraform-layout-example/blob/master/bin/aws-vault-wrapper) you can set the `AWS_VAULT_NO_SESSION` environment variable. If you don't do this you'll receive an `InvalidClientTokenId` error. 
+If your `aws` commands run via [aws-vault](https://github.com/99designs/aws-vault), you'll need to set the `--no-session` flag so the IAM operations can run without being MFA'd. If you're using the [Truss aws-vault-wrapper](https://github.com/trussworks/terraform-layout-example/blob/master/bin/aws-vault-wrapper) you can set the `AWS_VAULT_NO_SESSION` environment variable. If you don't do this you'll receive an `InvalidClientTokenId` error.
 
 If you are running the aws-vault-wrapper as noted above, you will want to run this script without `AWS_VAULT_NO_SESSION`. The role assumption between different profiles requires session behavior. Additionally, this script will attempt to run `aws s3 ls` before checking for bucket existence so that you can create a session token that may require an MFA handshake.
 

--- a/bootstrap
+++ b/bootstrap
@@ -22,7 +22,8 @@ readonly tfvars_file=terraform.tfvars
 
 bucket_exists() {
     bucket=$1
-    status=$(aws s3 ls "s3://$bucket/" 2>&1 | grep -o 'bucket does not exist') || true
+    output=$(aws s3 ls "s3://$bucket/")
+    status=$(echo "$output" | grep -o 'bucket does not exist') || true
     [[ $status != 'bucket does not exist' ]]
 }
 

--- a/bootstrap
+++ b/bootstrap
@@ -21,7 +21,7 @@ readonly logging_bucket=${account_alias}-terraform-state-logs-${region}
 readonly tfvars_file=terraform.tfvars
 
 # If you are running this with aws-vault and using sessions so you can
-# assume roles cross-account with MFA enabled you will want to run an 
+# assume roles cross-account with MFA enabled you will want to run an
 # arbitrary aws command to instanstiate a session before we need to examine output.
 if [[ -z "${AWS_VAULT_NO_SESSION+x}" || "${AWS_VAULT_NO_SESSION}" != "true" ]]; then
     aws s3 ls
@@ -32,7 +32,7 @@ bucket_exists() {
     output=$(aws s3 ls "s3://$bucket/" 2>&1)
     exit_code="$?"
     status=$(echo "$output" | grep -o 'bucket does not exist') || true
-    if [[ -z "$status" && "$exit_code" > 0 ]]; then
+    if [[ -z "$status" && "$exit_code" -gt 0 ]]; then
         echo "$output"
         exit 1
     fi

--- a/bootstrap
+++ b/bootstrap
@@ -30,7 +30,6 @@ bucket_exists() {
     [[ $status != 'bucket does not exist' ]]
 }
 
-
 # Bail out if the state bucket already exists
 if bucket_exists "$state_bucket"; then
     set +x

--- a/bootstrap
+++ b/bootstrap
@@ -20,13 +20,22 @@ readonly state_bucket=${account_alias}-terraform-state-${region}
 readonly logging_bucket=${account_alias}-terraform-state-logs-${region}
 readonly tfvars_file=terraform.tfvars
 
-# Run an arbitrary AWS command to create a session. This only matters if you are
-# running this script without AWS_VAULT_NO_SESSION so you can use a cross account role assumption.
-aws s3 ls
+# If you are running this with aws-vault and using sessions so you can
+# assume roles cross-account with MFA enabled you will want to run an 
+# arbitrary aws command to instanstiate a session before we need to examine output.
+if [[ -z "${AWS_VAULT_NO_SESSION+x}" || "${AWS_VAULT_NO_SESSION}" != "true" ]]; then
+    aws s3 ls
+fi
 
 bucket_exists() {
     bucket=$1
-    status=$(aws s3 ls "s3://$bucket/" 2>&1 | grep -o 'bucket does not exist') || true
+    output=$(aws s3 ls "s3://$bucket/" 2>&1)
+    exit_code="$?"
+    status=$(echo "$output" | grep -o 'bucket does not exist') || true
+    if [[ -z "$status" && "$exit_code" > 0 ]]; then
+        echo "$output"
+        exit 1
+    fi
     [[ $status != 'bucket does not exist' ]]
 }
 

--- a/bootstrap
+++ b/bootstrap
@@ -20,10 +20,13 @@ readonly state_bucket=${account_alias}-terraform-state-${region}
 readonly logging_bucket=${account_alias}-terraform-state-logs-${region}
 readonly tfvars_file=terraform.tfvars
 
+# Run an arbitrary AWS command to create a session. This only matters if you are
+# running this script without AWS_VAULT_NO_SESSION so you can use a cross account role assumption.
+aws s3 ls
+
 bucket_exists() {
     bucket=$1
-    output=$(aws s3 ls "s3://$bucket/")
-    status=$(echo "$output" | grep -o 'bucket does not exist') || true
+    status=$(aws s3 ls "s3://$bucket/" 2>&1 | grep -o 'bucket does not exist') || true
     [[ $status != 'bucket does not exist' ]]
 }
 


### PR DESCRIPTION
Bugfixes:
- In the case that you are running your aws-vault commands with sessions, perform an aws command to start a session before we need to capture output so we can do thee MFA handshake.
- When checking for bucket existence, bail out if there are other errors in the return.

Additionally, updates README.md.

Please see:
https://www.pivotaltracker.com/story/show/168528501