### PR TITLE
Swap out git commit command for a message

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -76,9 +76,7 @@ terraform init
 terraform apply -auto-approve
 
 # Save the region and local state
-git add "$tfvars_file" terraform.tfstate
-git commit -m "Bootstrapped Terraform remote state setup"
-
 echo
 echo
-echo "To complete the bootstrap process, push these changes to your repo!"
+echo "To complete the bootstrap process, you must commit the terraform state files to source control. For example:"
+echo "git add $tfvars_file terraform.tfstate && git commit -m -n 'Bootstrapped Terraform remote state setup' && git push"


### PR DESCRIPTION
As written, this script commits the terraform state files to source
control and then asks the user to complete the process by pushing the
changes up.

However, if the user has any changes staged in source control when
running this script, they will be automatically committed along with the
terraform state files using our hard-coded commit message.

Also, the script will add this commit to whatever branch the user has
checked out when it is invoked.

This change removes the commands that affect git state, and extends the
manual intervention requested from the user to include staging &
committing the state files.