### PR TITLE
Updating version of aws-logs for govcloud compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 4.1.1"
+  version = "~> 5.2.0"
   region  = var.region
 
   s3_bucket_name = var.logging_bucket


### PR DESCRIPTION
Updates the version of `terraform-aws-logs` to the GovCloud compatible version.