### PR TITLE
update versions and naming convention on state buckets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:4013bb8c2428b3e2755d90a922abb2a6cea37ab4
+      - image: trussworks/circleci-docker-primary:8122ec14fdda6e5f18457385e4c70351c2d54523
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.27.0
+    rev: v1.29.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are running your `aws` commands via [aws-vault](https://github.com/99desi
 Run the `bootstrap` script, specifying your AWS account alias and region:
 
 ```sh
-./bootstrap my-account-alias us-west-2
+./bootstrap my-account-alias region
 ```
 
 The account alias will be configured (if not set), the resources will be created, and a git commit will be made with the tfvars and state files. Push those changes to your repo.

--- a/bootstrap
+++ b/bootstrap
@@ -16,8 +16,8 @@ set -u
 readonly account_alias=$1
 readonly region=$2
 
-readonly state_bucket=${account_alias}-terraform-state-${region}
-readonly logging_bucket=${account_alias}-terraform-state-logs-${region}
+readonly state_bucket=${account_alias}-tf-state-${region}
+readonly logging_bucket=${account_alias}-tf-state-log-${region}
 readonly tfvars_file=terraform.tfvars
 
 # If you are running this with aws-vault and using sessions so you can

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 6.0"
+  version = "~> 8.0"
   region  = var.region
 
   s3_bucket_name = var.logging_bucket

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.54"
+  version = "~> 2.58"
   region  = var.region
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "region" {
 }
 
 variable "state_bucket" {
-  description = "S3 bucket to store Terraform state in ."
+  description = "S3 bucket to store Terraform state in."
   type        = string
 }
 


### PR DESCRIPTION
Versions were out of date! And our naming conventions were taking bucket names TO THE CHARACTER LI
Boy do we have fun.

Anyway, this PR updates. Should not impact instances where we've already used because we won't run the script again.

