### PR TITLE
Updating circleci image for shell-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: trussworks/circleci-docker-primary:8122ec14fdda6e5f18457385e4c70351c2d54523
+      - image: trussworks/circleci-docker-primary:ffbfa3d3e13660c63ec50154a0323190825d1fb0
     steps:
       - checkout
       - restore_cache:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,8 @@ repos:
     hooks:
       - id: terraform_docs
       - id: terraform_fmt
+
+  - repo: git://github.com/detailyang/pre-commit-shell
+    rev: 1.0.5
+    hooks:
+      - id: shell-lint


### PR DESCRIPTION
This is to update the container to the latest one to get Mike's fix for the shell-lint source.