### PR TITLE
Add functionality to pre-clean repo before bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -13,6 +13,23 @@ usage() {
 [[ -z $1 || -z $2 ]] && usage
 set -u
 
+# This repo is a template to be cloned into other repos
+# When it is used several files should be removed that are part of the repo but should not be included
+# in the new repo. This section asks if the user want's to remove the files.
+if [ -d .git ]; then
+    while true; do
+      read -rp "Do you wish to remove the template repo's config files before continuing? " yn
+      case $yn in
+        [Yy]* )
+            echo "Removing files: .git LICENSE .circleci .gitignore .markdownlintrc .pre-commit-config.yaml"
+            rm -rf .git LICENSE .circleci .gitignore .markdownlintrc .pre-commit-config.yaml
+            break;;
+        [Nn]* ) break;;
+        * ) echo "Please answer yes or no.";;
+      esac
+    done
+fi
+
 readonly account_alias=$1
 readonly region=$2
 


### PR DESCRIPTION
Documentation for using this repo usually has this in it:

```sh
git clone git@github.com:trussworks/terraform-aws-bootstrap.git bootstrap
cd bootstrap && rm -rf .git LICENSE .circleci .gitignore .markdownlintrc .pre-commit-config.yaml
./bootstrap trussworks-<NAME> us-west-2
```

It would be better if the script managed the file removal as part of the `bootstrap` script. Because some folks may not want files to disappear on them silently I've added a question into the bootstrap script which makes it optional. Now you'll see this additional output in the script:

```sh
./bootstrap trussworks-<NAME> us-west-2
Do you wish to remove the template repo's config files before continuing? Y
Removing files: .git LICENSE .circleci .gitignore .markdownlintrc .pre-commit-config.yaml
...
```