### PR TITLE
Fix bucket name and improve upgrade path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Terraform 0.12. Pin module version to latest. Submit pull-requests to master bra
 
 ```hcl
 module "bootstrap" {
-  source = "terraform/bootstrap/aws"
+  source = "trussworks/bootstrap/aws"
 
   region        = "us-west-2"
   account_alias = "<ORG>-<NAME>"

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 
 locals {
   state_bucket   = "${var.account_alias}-tf-state-${var.region}"
-  logging_bucket = "${var.account_alias}-tf-state-logs-${var.region}"
+  logging_bucket = "${var.account_alias}-tf-state-log-${var.region}"
 }
 
 resource "aws_iam_account_alias" "alias" {


### PR DESCRIPTION
The goal of this PR was to improve documentation about an upgrade path for folks moving from how this module used to work to how it works as a terraform module. Along the way I discovered an issue with bucket naming that made the upgrade path too difficult and so I fixed it for backwards compatibility. 

I intend to release as `v0.1.1`.