### PR TITLE
Setting log_retention as var with default of 731 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module "bootstrap" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | account\_alias | The desired AWS account alias. | `string` | n/a | yes |
-| log\_retention | Log retention of access logs of state bucket. | `number` | `731` | no |
+| log\_retention | Log retention of access logs of state bucket. | `number` | `90` | no |
 | region | AWS region. | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module "bootstrap" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | account\_alias | The desired AWS account alias. | `string` | n/a | yes |
+| log\_retention | Log retention of access logs of state bucket. | `number` | `731` | no |
 | region | AWS region. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -33,9 +33,9 @@ module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
   version = "~> 8.0.1"
 
-  region         = var.region
-  s3_bucket_name = local.logging_bucket
-  default_allow  = false
+  region                  = var.region
+  s3_bucket_name          = local.logging_bucket
+  default_allow           = false
   s3_log_bucket_retention = var.log_retention
 }
 

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,7 @@ module "terraform_state_bucket_logs" {
   region         = var.region
   s3_bucket_name = local.logging_bucket
   default_allow  = false
+  s3_log_bucket_retention = var.log_retention
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "account_alias" {
   description = "The desired AWS account alias."
   type        = string
 }
+
+variable "log_retention" {
+  description = "Log retention of access logs of state bucket."
+  default = 731
+  type        = number
+}

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,6 @@ variable "account_alias" {
 
 variable "log_retention" {
   description = "Log retention of access logs of state bucket."
-  default = 731
+  default     = 731
   type        = number
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,6 @@ variable "account_alias" {
 
 variable "log_retention" {
   description = "Log retention of access logs of state bucket."
-  default     = 731
+  default     = 90
   type        = number
 }


### PR DESCRIPTION
This PR sets the default object retention for the state logging bucket to be a variable with a default of 731 days, greater than 2 years.

We are using this on a project and generated a `terraform plan` to show the changes. Part of the plan has been removed.

```

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.bootstrap.module.terraform_state_bucket_logs.aws_s3_bucket.aws_logs will be updated in-place
  ~ resource "aws_s3_bucket" "aws_logs" {
        acl                         = "log-delivery-write"
      ~ lifecycle_rule {
            abort_incomplete_multipart_upload_days = 0
            enabled                                = true
            id                                     = "expire_all_logs"
            prefix                                 = "/*"
            tags                                   = {}

          ~ expiration {
              ~ days                         = 90 -> 731
                expired_object_delete_marker = false
            }
        }

        server_side_encryption_configuration {
            rule {
                apply_server_side_encryption_by_default {
                    sse_algorithm = "AES256"
                }
            }
        }

        versioning {
            enabled    = false
            mfa_delete = false
        }
    }
```