### PR TITLE
Update module dependency pinned versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,6 @@ module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
   version = "~> 10.0.0"
 
-  region                  = var.region
   s3_bucket_name          = local.logging_bucket
   default_allow           = false
   s3_log_bucket_retention = var.log_retention

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_iam_account_alias" "alias" {
 
 module "terraform_state_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 2.0.10"
+  version = "~> 3.0.0"
 
   bucket         = local.state_bucket
   logging_bucket = module.terraform_state_bucket_logs.aws_logs_bucket
@@ -31,7 +31,7 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 8.0.1"
+  version = "~> 10.0.0"
 
   region                  = var.region
   s3_bucket_name          = local.logging_bucket


### PR DESCRIPTION
Hi guys, I came across your module and found that the dependencies are pinned for version 0.12. I have taken the liberty of updating them to your newest versions,
- 3.0 for private-s3-bucket
- 10.0.0 for the log module

Additionally, I dropped a now-deprecated argument for the `region` within the log module.