### PR TITLE
Updating version req in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "bootstrap" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
+| terraform | >= 0.13.0 |
 | aws | ~> 3.0 |
 
 ## Providers


### PR DESCRIPTION
Looks like when the version requirement was changed, the README wasn't updated, and that was causing terraform docs precommit hooks to fail; also, when Eady merged in that change, no new release was cut. I've fixed the README and I'll cut a new release after merge.