### PR TITLE
adding versioning for log bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "bootstrap" {
 | bucket\_purpose | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
 | dynamodb\_table\_name | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
 | dynamodb\_table\_tags | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | <pre>{<br>  "Automation": "Terraform",<br>  "Name": "terraform-state-lock"<br>}</pre> | no |
+| log\_bucket\_versioning | Bool for toggling versioning for log bucket | `bool` | `false` | no |
 | log\_name | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |
 | log\_retention | Log retention of access logs of state bucket. | `number` | `90` | no |
 | region | AWS region. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -31,11 +31,12 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 10.2.0"
+  version = "~> 10.3.0"
 
   s3_bucket_name          = local.logging_bucket
   default_allow           = false
   s3_log_bucket_retention = var.log_retention
+  enable_versioning       = var.log_bucket_versioning
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,9 @@ variable "log_name" {
   default     = "log"
   type        = string
 }
+
+variable "log_bucket_versioning" {
+  description = "Bool for toggling versioning for log bucket"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This adds the ability to turn on versioning for the state log bucket, which is something we need to make CMS happy.