### PR TITLE
relax aws provider constraint to allow for use with terraform 0.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+      image: trussworks/circleci:56d41758666174506ef9a98769e448c63acc2045
     steps:
     - checkout
     - restore_cache:
@@ -16,7 +16,7 @@ jobs:
         paths:
         - ~/.cache/pre-commit
 references:
-  circleci: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+  circleci: trussworks/circleci:56d41758666174506ef9a98769e448c63acc2045
 version: 2.1
 workflows:
   validate:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -8,12 +8,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.27.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.48.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ensure_pre_commit: .git/hooks/pre-commit ## Ensure pre-commit is installed
 
 .PHONY: pre_commit_tests
 pre_commit_tests: ensure_pre_commit ## Run pre-commit tests
-	pre-commit run --all-files
+	pre-commit run --all-files --show-diff-on-failure
 
 .PHONY: test
 test: pre_commit_tests

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ ensure_pre_commit: .git/hooks/pre-commit ## Ensure pre-commit is installed
 
 .PHONY: pre_commit_tests
 pre_commit_tests: ensure_pre_commit ## Run pre-commit tests
+	pre-commit --version
 	pre-commit run --all-files --show-diff-on-failure
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If the AWS account you are using already has a Terraform state bucket and lockin
 
 ## Terraform Versions
 
-Terraform 0.13. Pin module version to latest. Submit pull-requests to master branch.
+Terraform 0.13 and higher. Pin module version to latest. Submit pull-requests to master branch.
 
 Terraform 0.12. Pin module version to v0.1.4. Submit pull-requests to terraform012 branch.
 
@@ -31,36 +31,49 @@ module "bootstrap" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
-| aws | ~> 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_terraform_state_bucket"></a> [terraform\_state\_bucket](#module\_terraform\_state\_bucket) | trussworks/s3-private-bucket/aws | ~> 3.3.0 |
+| <a name="module_terraform_state_bucket_logs"></a> [terraform\_state\_bucket\_logs](#module\_terraform\_state\_bucket\_logs) | trussworks/logs/aws | ~> 10.3.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.terraform_state_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_account_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| account\_alias | The desired AWS account alias. | `string` | n/a | yes |
-| bucket\_purpose | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
-| dynamodb\_table\_name | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
-| dynamodb\_table\_tags | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | <pre>{<br>  "Automation": "Terraform",<br>  "Name": "terraform-state-lock"<br>}</pre> | no |
-| log\_bucket\_versioning | Bool for toggling versioning for log bucket | `bool` | `false` | no |
-| log\_name | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |
-| log\_retention | Log retention of access logs of state bucket. | `number` | `90` | no |
-| region | AWS region. | `string` | n/a | yes |
+| <a name="input_account_alias"></a> [account\_alias](#input\_account\_alias) | The desired AWS account alias. | `string` | n/a | yes |
+| <a name="input_bucket_purpose"></a> [bucket\_purpose](#input\_bucket\_purpose) | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
+| <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
+| <a name="input_dynamodb_table_tags"></a> [dynamodb\_table\_tags](#input\_dynamodb\_table\_tags) | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | <pre>{<br>  "Automation": "Terraform",<br>  "Name": "terraform-state-lock"<br>}</pre> | no |
+| <a name="input_log_bucket_versioning"></a> [log\_bucket\_versioning](#input\_log\_bucket\_versioning) | Bool for toggling versioning for log bucket | `bool` | `false` | no |
+| <a name="input_log_name"></a> [log\_name](#input\_log\_name) | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |
+| <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Log retention of access logs of state bucket. | `number` | `90` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| dynamodb\_table | The name of the dynamo db table |
-| logging\_bucket | The logging\_bucket name |
-| state\_bucket | The state\_bucket name |
-
+| <a name="output_dynamodb_table"></a> [dynamodb\_table](#output\_dynamodb\_table) | The name of the dynamo db table |
+| <a name="output_logging_bucket"></a> [logging\_bucket](#output\_logging\_bucket) | The logging\_bucket name |
+| <a name="output_state_bucket"></a> [state\_bucket](#output\_state\_bucket) | The state\_bucket name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Bootstrapping

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
Additionally, fix various pre-commit issues and add more verbosity and information to the pre-commit output in CI.