### PR TITLE
Enable point-in-time recovery for dynamodb table.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,7 @@ module "terraform_state_bucket_logs" {
 # Terraform state locking
 #
 
+#tfsec:ignore:AWS086
 resource "aws_dynamodb_table" "terraform_state_lock" {
   name           = var.dynamodb_table_name
   hash_key       = "LockID"
@@ -57,7 +58,7 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
   }
 
   point_in_time_recovery {
-    enabled = true
+    enabled = var.point_in_time_recovery
   }
 
   tags = var.dynamodb_table_tags

--- a/main.tf
+++ b/main.tf
@@ -56,5 +56,9 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
     type = "S"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   tags = var.dynamodb_table_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
   }
 
   point_in_time_recovery {
-    enabled = var.point_in_time_recovery
+    enabled = var.dynamodb_point_in_time_recovery
   }
 
   tags = var.dynamodb_table_tags

--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,8 @@ module "terraform_state_bucket_logs" {
 # Terraform state locking
 #
 
+# Ignore warnings about point-in-time recovery since this table holds no data
+# The terraform state lock is meant to be ephemeral and does not need recovery
 #tfsec:ignore:AWS086
 resource "aws_dynamodb_table" "terraform_state_lock" {
   name           = var.dynamodb_table_name

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "enable_s3_public_access_block" {
   default     = true
 }
 
-variable "point_in_time_recovery" {
+variable "dynamodb_point_in_time_recovery" {
   type        = bool
   default     = false
   description = "Point-in-time recovery options"

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,9 @@ variable "state_bucket_tags" {
   default     = { Automation : "Terraform" }
   description = "Tags to associate with the bucket storing the Terraform state files"
 }
+
+variable "point_in_time_recovery" {
+  type        = bool
+  default     = false
+  description = "Point-in-time recovery options"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "state_bucket_tags" {
   description = "Tags to associate with the bucket storing the Terraform state files"
 }
 
+variable "enable_s3_public_access_block" {
+  description = "Bool for toggling whether the s3 public access block resource should be enabled."
+  type        = bool
+  default     = true
+}
+
 variable "point_in_time_recovery" {
   type        = bool
   default     = false


### PR DESCRIPTION
When using `tfsec` to analyze this code it comes back with this warning:

```

      42 | # Terraform state locking
      43 | #
      44 | 
      45 | resource "aws_dynamodb_table" "terraform_state_lock" {
      46 |   name           = var.dynamodb_table_name
      47 |   hash_key       = "LockID"
      48 |   read_capacity  = 2
      49 |   write_capacity = 2
      50 | 
      51 |   server_side_encryption {
      52 |     enabled = true
      53 |   }
      54 | 
      55 |   attribute {
      56 |     name = "LockID"
      57 |     type = "S"
      58 |   }
      59 | 
      60 |   tags = var.dynamodb_table_tags
      61 | }
      62 | 

  Impact:     Accidental or malicious writes and deletes can't be rolled back
  Resolution: Enable point in time recovery

  https://tfsec.dev/docs/aws/AWS086/ 
  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#point_in_time_recovery 
  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/PointInTimeRecovery.html 
```

The fix is simple and feels like a good default for folks.