### PR TITLE
Updating s3-private-bucket version to fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "bootstrap" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_terraform_state_bucket"></a> [terraform\_state\_bucket](#module\_terraform\_state\_bucket) | trussworks/s3-private-bucket/aws | ~> 3.3.0 |
+| <a name="module_terraform_state_bucket"></a> [terraform\_state\_bucket](#module\_terraform\_state\_bucket) | trussworks/s3-private-bucket/aws | ~> 3.6.0 |
 | <a name="module_terraform_state_bucket_logs"></a> [terraform\_state\_bucket\_logs](#module\_terraform\_state\_bucket\_logs) | trussworks/logs/aws | ~> 10.3.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "aws_iam_account_alias" "alias" {
 
 module "terraform_state_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 3.3.0"
+  version = "~> 3.6.0"
 
   bucket         = local.state_bucket
   logging_bucket = module.terraform_state_bucket_logs.aws_logs_bucket


### PR DESCRIPTION
This fixes an issue introduced in the last version -- the new functionality requires updating the version of the s3 private bucket module in the module, which we missed.