### PR TITLE
Switch to running the terraform-docs action on pushes to main

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,8 @@
 name: terraform-docs-gh-actions
-on: [pull_request, pull_request_target]
+on:
+  push:
+    branches:
+      - main
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -10,9 +13,7 @@ jobs:
     - name: checkout project
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+        ref: main
     - name: Render terraform docs inside the README.md and push changes back to branch
       uses: terraform-docs/gh-actions@v0.9.0
       with:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ module "bootstrap" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_alias"></a> [account\_alias](#input\_account\_alias) | The desired AWS account alias. | `string` | n/a | yes |
 | <a name="input_bucket_purpose"></a> [bucket\_purpose](#input\_bucket\_purpose) | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
+| <a name="input_dynamodb_point_in_time_recovery"></a> [dynamodb\_point\_in\_time\_recovery](#input\_dynamodb\_point\_in\_time\_recovery) | Point-in-time recovery options | `bool` | `false` | no |
 | <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
 | <a name="input_dynamodb_table_tags"></a> [dynamodb\_table\_tags](#input\_dynamodb\_table\_tags) | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | <pre>{<br>  "Automation": "Terraform",<br>  "Name": "terraform-state-lock"<br>}</pre> | no |
 | <a name="input_enable_s3_public_access_block"></a> [enable\_s3\_public\_access\_block](#input\_enable\_s3\_public\_access\_block) | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |


### PR DESCRIPTION
This is due to various permission issues with forked PRs. See an example in https://github.com/trussworks/terraform-aws-bootstrap/pull/54