### PR TITLE
Account alias management is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ terraform {
 
 ## Upgrade Path
 
-### Release v1.1.0
+### Release v1.7.0
 
-When upgrading from v1.0.1 to v1.1.0 the terraform state must be modified to move the account alias resource:
+When upgrading from v1.6.1 to v1.7.0 the terraform state must be modified to move the account alias resource:
 
 ```sh
 terraform state mv aws_iam_account_alias.alias aws_iam_account_alias.alias[0]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ terraform {
 When upgrading from v1.6.1 to v2.0.0 the terraform state must be modified to move the account alias resource:
 
 ```sh
-terraform state mv aws_iam_account_alias.alias aws_iam_account_alias.alias[0]
+terraform state mv module.example.aws_iam_account_alias.alias module.example.aws_iam_account_alias.alias[0]
 ```
 
 If you do not want to manage the account alias with this module you can instead use a data resource

--- a/README.md
+++ b/README.md
@@ -137,6 +137,28 @@ terraform {
 
 ## Upgrade Path
 
+### Release v1.1.0
+
+When upgrading from v1.0.1 to v1.1.0 the terraform state must be modified to move the account alias resource:
+
+```sh
+terraform state mv aws_iam_account_alias.alias aws_iam_account_alias.alias[0]
+```
+
+If you do not want to manage the account alias with this module you can instead use a data resource
+to get the account alias and pass it into the module. Also set `manage_account_alias` to `false`.
+
+```hcl
+data "aws_iam_account_alias" "current" {}
+module "bootstrap" {
+  source = "trussworks/bootstrap/aws"
+
+  region               = "us-west-2"
+  account_alias        = data.aws_iam_account_alias.current.id
+  manage_account_alias = false
+}
+```
+
 ### Pre-module release to v0.1.1
 
 To update from the pre-module release code that cloned this repo to the module release you'll need to do a few things:

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ terraform {
 
 ## Upgrade Path
 
-### Release v1.7.0
+### Release v2.0.0
 
-When upgrading from v1.6.1 to v1.7.0 the terraform state must be modified to move the account alias resource:
+When upgrading from v1.6.1 to v2.0.0 the terraform state must be modified to move the account alias resource:
 
 ```sh
 terraform state mv aws_iam_account_alias.alias aws_iam_account_alias.alias[0]

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ locals {
 }
 
 resource "aws_iam_account_alias" "alias" {
+  count         = var.manage_account_alias ? 1 : 0
   account_alias = var.account_alias
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,9 @@ variable "dynamodb_point_in_time_recovery" {
   default     = false
   description = "Point-in-time recovery options"
 }
+
+variable "manage_account_alias" {
+  type        = bool
+  default     = true
+  description = "Manage the account alias as a resource. Set to 'false' if this behavior is not desired."
+}


### PR DESCRIPTION
With this change I'm allowing the account alias management to be optional. This is useful in the event that an AWS account has already been set up and the alias cannot be changed (and should not be managed because of legacy issues). It still let's folks set up the terraform state bucket and dynamodb table. An example of the new usage is included as well as migration instructions.