### PR TITLE
Provide an upgrade path to AWS provider 4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
       - id: detect-private-key
       - id: trailing-whitespace
 
-  - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.27.1
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.31.1
     hooks:
       - id: markdownlint
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.48.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ module "terraform_state_bucket_logs" {
   s3_bucket_name          = local.logging_bucket
   default_allow           = false
   s3_log_bucket_retention = var.log_retention
-  enable_versioning       = var.log_bucket_versioning
+  versioning_status       = var.log_bucket_versioning
 
   tags = var.log_bucket_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -17,12 +17,16 @@ module "terraform_state_bucket" {
   version = "~> 4.0.0"
 
   bucket         = local.state_bucket
-  logging_bucket = module.terraform_state_bucket_logs.aws_logs_bucket
+  logging_bucket = local.logging_bucket
 
   use_account_alias_prefix = false
 
   enable_s3_public_access_block = var.enable_s3_public_access_block
   tags                          = var.state_bucket_tags
+
+  depends_on = [
+    module.terraform_state_bucket_logs
+  ]
 }
 
 #

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_iam_account_alias" "alias" {
 
 module "terraform_state_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 3.7.0"
+  version = "~> 4.0.0"
 
   bucket         = local.state_bucket
   logging_bucket = module.terraform_state_bucket_logs.aws_logs_bucket
@@ -31,7 +31,7 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 11.0.0"
+  version = "~> 13.0.0"
 
   s3_bucket_name          = local.logging_bucket
   default_allow           = false

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,8 @@ module "terraform_state_bucket_logs" {
   default_allow           = false
   s3_log_bucket_retention = var.log_retention
   enable_versioning       = var.log_bucket_versioning
+
+  tags = var.log_bucket_tags
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "state_bucket_tags" {
   description = "Tags to associate with the bucket storing the Terraform state files"
 }
 
+variable "log_bucket_tags" {
+  type        = map(string)
+  default     = { Automation : "Terraform" }
+  description = "Tags to associate with the bucket storing the Terraform state bucket logs"
+}
+
 variable "enable_s3_public_access_block" {
   description = "Bool for toggling whether the s3 public access block resource should be enabled."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -42,9 +42,13 @@ variable "log_name" {
 }
 
 variable "log_bucket_versioning" {
-  description = "Bool for toggling versioning for log bucket"
-  type        = bool
-  default     = false
+  description = "A string that indicates the versioning status for the log bucket."
+  default     = "Disabled"
+  type        = string
+  validation {
+    condition     = contains(["Enabled", "Disabled", "Suspended"], var.log_bucket_versioning)
+    error_message = "Valid values for versioning_status are Enabled, Disabled, or Suspended."
+  }
 }
 
 variable "state_bucket_tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws = ">= 3.0, < 4.0"
+    aws = ">= 3.75.0"
   }
 }


### PR DESCRIPTION
- BREAKING CHANGE: Changed the `log_bucket_versioning` variable from a boolean to a string.
- Updated pre-commit hooks.
- Bumped module versions to be compatible with the AWS 4 provider.
- Set the minimum AWS provider version to 3.75.0, which is the version that contains backported AWS S3 resource functionality that was added in 4.0.
- Started managing tags for the logging bucket to maintain the same behavior that existed prior to https://github.com/trussworks/terraform-aws-bootstrap/pull/65.
- Removed inter-module dependency between the state bucket and the logging bucket.
- Added instructions for how to upgrade once the breaking change is released along with the module version bump.