### PR TITLE
ci: removing pr limit from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,6 @@
       ]
     }
   ],
-  "prConcurrentLimit": 2,
   "schedule": [
     "every weekend"
   ],


### PR DESCRIPTION
removing PR limit in renovate to allow it to open as many PRs as it needs.
