### PR TITLE
"ci: validate-tf instead of validate and TFDocs GHA"

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: validate
+name: validate-tf
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  validate:
-    uses: trussworks/shared-actions/.github/workflows/validate.yml@main
+  validate-tf:
+    uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
     with:
       go-version: 1.19

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -25,7 +25,7 @@ repos:
         exclude: README.m(ark)?d(own)?
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.33.0
     hooks:
       - id: markdownlint
 
@@ -34,10 +34,13 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: "v0.16.0"
     hooks:
-      - id: terraform_docs
-        args:
-          - --args=--config=.terraform-docs.yml
+      - id: terraform-docs-go
+        args: ["markdown", "table", "--output-file", "README.md", "."]
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.1
+    hooks:
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -281,3 +281,58 @@ actions need to be performed.
 git checkout -b update_bootstrap_for_<ORG>_<NAME>
 git commit -am"Update the bootstrap stack to use the bootstrap terraform module"
 ```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13.0 |
+| aws | >= 3.75.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 3.75.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| terraform\_state\_bucket | trussworks/s3-private-bucket/aws | ~> 4.3.0 |
+| terraform\_state\_bucket\_logs | trussworks/logs/aws | ~> 14.2.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.terraform_state_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_account_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_alias) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| account\_alias | The desired AWS account alias. | `string` | n/a | yes |
+| bucket\_purpose | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
+| dynamodb\_point\_in\_time\_recovery | Point-in-time recovery options | `bool` | `false` | no |
+| dynamodb\_table\_name | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
+| dynamodb\_table\_tags | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | ```{ "Automation": "Terraform", "Name": "terraform-state-lock" }``` | no |
+| enable\_s3\_public\_access\_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
+| log\_bucket\_tags | Tags to associate with the bucket storing the Terraform state bucket logs | `map(string)` | ```{ "Automation": "Terraform" }``` | no |
+| log\_bucket\_versioning | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
+| log\_name | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |
+| log\_retention | Log retention of access logs of state bucket. | `number` | `90` | no |
+| manage\_account\_alias | Manage the account alias as a resource. Set to 'false' if this behavior is not desired. | `bool` | `true` | no |
+| region | AWS region. | `string` | n/a | yes |
+| state\_bucket\_tags | Tags to associate with the bucket storing the Terraform state files | `map(string)` | ```{ "Automation": "Terraform" }``` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| dynamodb\_table | The name of the dynamo db table |
+| logging\_bucket | The logging\_bucket name |
+| state\_bucket | The state\_bucket name |
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
# [Update terraform module template to use terraform-docs' own hook](https://trello.com/c/0eThuK02/241-update-terraform-module-template-to-use-terraform-docs-own-hook)
# [Update terraform modules to use new validate-tf shared action](https://trello.com/c/i1sHKDjQ/243-update-terraform-modules-to-use-new-validate-tf-shared-action)

- ci: validate-tf instead of validate
- ci: terraform docs official action

