### PR TITLE
Change default value of kms_master_key_id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -83,7 +83,7 @@ variable "manage_account_alias" {
 
 variable "kms_master_key_id" {
   type        = string
-  default     = null
+  default     = ""
   description = "The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket."
 }
 


### PR DESCRIPTION
Hi 

Nowadays the default value of `kms_master_key_id` on [terraform-aws-s3-private-bucket](https://github.com/trussworks/terraform-aws-s3-private-bucket) is `""`.

Changing the the default value on terraform-aws-bootstrap to make compatible. 

Related to [issue](https://github.com/trussworks/terraform-aws-s3-private-bucket/issues/399) on [terraform-aws-s3-private-bucket](https://github.com/trussworks/terraform-aws-s3-private-bucket)
