### PR TITLE
Add pull_request_target on main for GHA

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,3 +1,4 @@
+---
 name: validate-tf
 
 on:
@@ -5,6 +6,9 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
## [Investigate why GHA required checks are not running on commits pushed by the terraform-docs shared action](https://trello.com/c/Pqk0PC7y/300-investigate-why-gha-required-checks-are-not-running-on-commits-pushed-by-the-terraform-docs-shared-action)

Changes proposed in this pull request:

- Add pull_request_target to GHA. Trying to get the action to run on terraform-docs commits.
