### PR TITLE
Update dependencies s3-private-bucket@7.1.0, logs@16.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ module "bootstrap" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| terraform\_state\_bucket | trussworks/s3-private-bucket/aws | ~> 4.3.0 |
-| terraform\_state\_bucket\_logs | trussworks/logs/aws | ~> 14.2.0 |
+| terraform\_state\_bucket | trussworks/s3-private-bucket/aws | ~> 7.1.0 |
+| terraform\_state\_bucket\_logs | trussworks/logs/aws | ~> 16.1.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_iam_account_alias" "alias" {
 
 module "terraform_state_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 4.3.0"
+  version = "~> 7.1.0"
 
   bucket         = local.state_bucket
   logging_bucket = local.logging_bucket
@@ -22,7 +22,6 @@ module "terraform_state_bucket" {
   use_account_alias_prefix = false
   bucket_key_enabled       = var.bucket_key_enabled
   kms_master_key_id        = var.kms_master_key_id
-  sse_algorithm            = var.kms_master_key_id != null ? "aws:kms" : null
 
   enable_s3_public_access_block = var.enable_s3_public_access_block
   tags                          = var.state_bucket_tags
@@ -38,7 +37,7 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 14.2.0"
+  version = "~> 16.1.0"
 
   s3_bucket_name          = local.logging_bucket
   default_allow           = false


### PR DESCRIPTION
## [Trello Card Title](URL)

Changes to the underlying AWS services have prompted changes to the 's3-private-bucket' and 'logs' modules.   This PR adopts those changes for the bootstrap module as well

- upgrade trussworks/s3-private-bucket/aws to ~> 7.1.0
- upgrade trussworks/logs/aws to ~> 16.1.0