### PR TITLE
fixes AWS logs module ACL error on creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ module "terraform_state_bucket_logs" {
   default_allow           = false
   s3_log_bucket_retention = var.log_retention
   versioning_status       = var.log_bucket_versioning
+  object_ownership        = "ObjectWriter"
 
   tags = var.log_bucket_tags
 }


### PR DESCRIPTION
## [Debug AWS logs module ACL error](https://trello.com/c/y5OmZqNK/364-debug-aws-logs-module-acl-error)

Cleaning up an error while creating the tf logs bucket. Ownership of bucket must be "ObjectWriter" instead of the default "BucketOwnerEnforced" if creating/using an acl.

Note: using ACLs will be finally deprecated in some major change to the terraform provider and we should consider how we create these buckets.
