### PR TITLE
fix: allow_s3 on logs bucket and define log_prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfstate.*.backup
+.terraform.lock.hcl

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -4,5 +4,6 @@
   "first-line-h1": false,
   "line_length": false,
   "no-multiple-blanks": false,
-  "no-inline-html": false
+  "no-inline-html": false,
+  "no-alt-text": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -15,7 +15,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
+    rev: 0.7.21
     hooks:
       - id: mdformat
         additional_dependencies:
@@ -25,22 +25,16 @@ repos:
         exclude: README.m(ark)?d(own)?
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.43.0
     hooks:
       - id: markdownlint
 
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
-    hooks:
-      - id: shell-lint
-
   - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
+    rev: "v0.19.0"
     hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
+      - id: terraform-docs-system
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.1
+    rev: v1.96.3
     hooks:
       - id: terraform_fmt

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,35 @@
+version: ">= 0.19.0, < 1.0.0"
+
 settings:
   html: false
   anchor: false
+  escape: false
+  lockfile: false
+  hide-empty: true
 formatter: "markdown table"
+
+sort:
+  enabled: true
+  by: required
+
+sections:
+  show:
+    - requirements
+    - providers
+    - modules
+    - data-sources
+    - resources
+    - inputs
+    - outputs
+
+recursive:
+  enabled: false
+  include-main: false
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ module "bootstrap" {
 | Name | Version |
 |------|---------|
 | terraform | >= 1.0 |
-| aws | >= 3.75.0 |
+| aws | >= 5.43.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.75.0 |
+| aws | >= 5.43.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| terraform\_state\_bucket | trussworks/s3-private-bucket/aws | ~> 7.1.0 |
-| terraform\_state\_bucket\_logs | trussworks/logs/aws | ~> 16.2.0 |
+| terraform_state_bucket | trussworks/s3-private-bucket/aws | ~> 7.1.0 |
+| terraform_state_bucket_logs | trussworks/logs/aws | ~> 16.2.0 |
 
 ## Resources
 
@@ -52,29 +52,26 @@ module "bootstrap" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| account\_alias | The desired AWS account alias. | `string` | n/a | yes |
-| bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
-| bucket\_purpose | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
-| dynamodb\_point\_in\_time\_recovery | Point-in-time recovery options | `bool` | `false` | no |
-| dynamodb\_table\_name | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
-| dynamodb\_table\_tags | Tags of the DynamoDB Table for locking Terraform state. | `map(string)` | `{}` | no |
-| enable\_s3\_public\_access\_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
-| kms\_master\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket. | `string` | `""` | no |
-| log\_bucket\_tags | Tags to associate with the bucket storing the Terraform state bucket logs | `map(string)` | `{}` | no |
-| log\_bucket\_versioning | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
-| log\_name | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |
-| log\_retention | Log retention of access logs of state bucket. | `number` | `90` | no |
-| manage\_account\_alias | Manage the account alias as a resource. Set to 'false' if this behavior is not desired. | `bool` | `true` | no |
+| account_alias | The desired AWS account alias. | `string` | n/a | yes |
 | region | AWS region. | `string` | n/a | yes |
-| state\_bucket\_tags | Tags to associate with the bucket storing the Terraform state files | `map(string)` | `{}` | no |
+| bucket_key_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
+| bucket_purpose | Name to identify the bucket's purpose | `string` | `"tf-state"` | no |
+| dynamodb_point_in_time_recovery | Point-in-time recovery options | `bool` | `false` | no |
+| dynamodb_table_name | Name of the DynamoDB Table for locking Terraform state. | `string` | `"terraform-state-lock"` | no |
+| enable_s3_public_access_block | Bool for toggling whether the s3 public access block resource should be enabled. | `bool` | `true` | no |
+| kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket. | `string` | `""` | no |
+| log_bucket_versioning | A string that indicates the versioning status for the log bucket. | `string` | `"Disabled"` | no |
+| log_name | Log name (for backwards compatibility this can be modified to logs) | `string` | `"log"` | no |
+| log_retention | Log retention of access logs of state bucket. | `number` | `90` | no |
+| manage_account_alias | Manage the account alias as a resource. Set to 'false' if this behavior is not desired. | `bool` | `true` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| dynamodb\_table | The name of the dynamo db table |
-| logging\_bucket | The logging\_bucket name |
-| state\_bucket | The state\_bucket name |
+| dynamodb_table | The name of the dynamo db table |
+| logging_bucket | The logging_bucket name |
+| state_bucket | The state_bucket name |
 <!-- END_TF_DOCS -->
 
 ## Bootstrapping

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,6 @@ module "terraform_state_bucket" {
   kms_master_key_id        = var.kms_master_key_id
 
   enable_s3_public_access_block = var.enable_s3_public_access_block
-  tags                          = var.state_bucket_tags
 
   depends_on = [
     module.terraform_state_bucket_logs
@@ -37,14 +36,14 @@ module "terraform_state_bucket" {
 
 module "terraform_state_bucket_logs" {
   source  = "trussworks/logs/aws"
-  version = "~> 16.2.0"
+  version = "~> 16.3.0"
 
   s3_bucket_name          = local.logging_bucket
   default_allow           = false
+  allow_s3                = true
   s3_log_bucket_retention = var.log_retention
   versioning_status       = var.log_bucket_versioning
-
-  tags = var.log_bucket_tags
+  s3_logs_prefix          = "s3/${local.state_bucket}"
 }
 
 #
@@ -72,6 +71,4 @@ resource "aws_dynamodb_table" "terraform_state_lock" {
   point_in_time_recovery {
     enabled = var.dynamodb_point_in_time_recovery
   }
-
-  tags = var.dynamodb_table_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_iam_account_alias" "alias" {
 
 module "terraform_state_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 8.0.1"
+  version = "~> 8.0.2"
 
   bucket         = local.state_bucket
   logging_bucket = local.logging_bucket

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "aws_iam_account_alias" "alias" {
 
 module "terraform_state_bucket" {
   source  = "trussworks/s3-private-bucket/aws"
-  version = "~> 7.1.0"
+  version = "~> 8.0.1"
 
   bucket         = local.state_bucket
   logging_bucket = local.logging_bucket

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,12 @@
-variable "dynamodb_table_name" {
-  description = "Name of the DynamoDB Table for locking Terraform state."
-  default     = "terraform-state-lock"
-  type        = string
-}
-
-variable "dynamodb_table_tags" {
-  description = "Tags of the DynamoDB Table for locking Terraform state."
-  default     = {}
-  type        = map(string)
-}
-
-variable "region" {
-  description = "AWS region."
-  type        = string
-}
-
 variable "account_alias" {
   description = "The desired AWS account alias."
   type        = string
 }
 
-variable "log_retention" {
-  description = "Log retention of access logs of state bucket."
-  default     = 90
-  type        = number
+variable "bucket_key_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
 }
 
 variable "bucket_purpose" {
@@ -32,10 +15,28 @@ variable "bucket_purpose" {
   type        = string
 }
 
-variable "log_name" {
-  description = "Log name (for backwards compatibility this can be modified to logs)"
-  default     = "log"
+variable "dynamodb_point_in_time_recovery" {
+  type        = bool
+  default     = false
+  description = "Point-in-time recovery options"
+}
+
+variable "dynamodb_table_name" {
+  description = "Name of the DynamoDB Table for locking Terraform state."
+  default     = "terraform-state-lock"
   type        = string
+}
+
+variable "enable_s3_public_access_block" {
+  description = "Bool for toggling whether the s3 public access block resource should be enabled."
+  type        = bool
+  default     = true
+}
+
+variable "kms_master_key_id" {
+  type        = string
+  default     = ""
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket."
 }
 
 variable "log_bucket_versioning" {
@@ -48,28 +49,16 @@ variable "log_bucket_versioning" {
   }
 }
 
-variable "state_bucket_tags" {
-  type        = map(string)
-  default     = {}
-  description = "Tags to associate with the bucket storing the Terraform state files"
+variable "log_name" {
+  description = "Log name (for backwards compatibility this can be modified to logs)"
+  default     = "log"
+  type        = string
 }
 
-variable "log_bucket_tags" {
-  type        = map(string)
-  default     = {}
-  description = "Tags to associate with the bucket storing the Terraform state bucket logs"
-}
-
-variable "enable_s3_public_access_block" {
-  description = "Bool for toggling whether the s3 public access block resource should be enabled."
-  type        = bool
-  default     = true
-}
-
-variable "dynamodb_point_in_time_recovery" {
-  type        = bool
-  default     = false
-  description = "Point-in-time recovery options"
+variable "log_retention" {
+  description = "Log retention of access logs of state bucket."
+  default     = 90
+  type        = number
 }
 
 variable "manage_account_alias" {
@@ -78,14 +67,7 @@ variable "manage_account_alias" {
   description = "Manage the account alias as a resource. Set to 'false' if this behavior is not desired."
 }
 
-variable "kms_master_key_id" {
+variable "region" {
+  description = "AWS region."
   type        = string
-  default     = ""
-  description = "The AWS KMS master key ID used for the SSE-KMS encryption of the state bucket."
-}
-
-variable "bucket_key_enabled" {
-  type        = bool
-  default     = false
-  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75.0"
+      version = ">= 5.43.0"
     }
   }
 }


### PR DESCRIPTION
- **chore: ignore terraform lock file**
- **chore: pre-commit autoupdate**
- **chore: sort variables and remove unused variables**
- **fix: fixes #122**
- **docs: terraform_docs**

I noticed that `default_allow = false` was set, not allowing any logging from AWS sources, but in order to log from S3 we need `allow_s3 = true` to be set. In addition, we need the `s3_logs_prefix` as well. This fixes #122. 

In addition, I set the `trussworks/logs/aws` module version to `16.3.0` which needs [this](https://github.com/trussworks/terraform-aws-logs/pull/317) merged first. This is also what's driving the `5.43.0` minimum AWS provider version as there are fixes released in that version that don't exist in versions prior. It's possible, we also wait for [this](https://github.com/trussworks/terraform-aws-s3-private-bucket/pull/408) PR and change the `trussworks/s3-private-bucket/aws` module version also.

I also sorted the `variables.tf` and removed unused variables.
